### PR TITLE
Update ssh_disable_coredump.yml

### DIFF
--- a/detections/ssh_disable_coredump.yml
+++ b/detections/ssh_disable_coredump.yml
@@ -17,7 +17,7 @@ detection:
         Image|endswith: 
             - '/esxcli'
     selection_cmd:
-        CommandLine|contains:
+        CommandLine|contains|all:
             - 'system'
             - 'coredump'
             - 'file'
@@ -26,7 +26,7 @@ detection:
         CommandLine|contains:
             - '-u'
             - '--unconfigure'
-    condition: selection_img and 1 of selection_cmd*
+    condition: selection_img and selection_cmd and selection_unconfigure_switch
 falsepositives:
     - Legitimate system administration actions
 level: high


### PR DESCRIPTION
changes proposed:
1) selection_cmd CommandLine selector changed from "contains" to "contains|all"

2) condition changed such that it includes all three selections  

==========================================

based on info available on LOLESXi, coredump can be disabled using following command 

esxcli system coredump file set --unconfigure

exiting logic makes the rule trigger on presence of either "system", "coredump", "file" or "set" and totally neglects "--unconfigure" flag